### PR TITLE
Add CRM base auth files

### DIFF
--- a/app/kanban/page.tsx
+++ b/app/kanban/page.tsx
@@ -1,0 +1,42 @@
+import { supabaseServer } from '@/lib/supabase-server'
+
+type Stage = { id: string; name: string; position: number }
+type Card = {
+  id: string; contact: string; interest: 'Ahorro'|'GMM'|'Ambos'
+  amount_estimated: number | null; next_step_at: string
+  stage: string
+}
+
+export default async function Kanban() {
+  const s = supabaseServer()
+  const { data: stages } = await s.from('crm.stages').select('id,name,position').order('position')
+  const { data: opps }   = await s.from('crm.v_opps_kanban').select('*')
+
+  const grouped: Record<string, Card[]> = {}
+  stages?.forEach((st: Stage) => (grouped[st.name] = []))
+  opps?.forEach((o: any) => { (grouped[o.stage] ||= []).push(o as Card) })
+
+  return (
+    <main className="p-6 grid gap-4 grid-cols-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
+      {stages?.map((st: Stage) => (
+        <section key={st.id} className="bg-white border rounded-2xl p-3">
+          <h2 className="font-semibold mb-2">{st.position}. {st.name}</h2>
+          <div className="space-y-2">
+            {grouped[st.name]?.map((card: Card) => (
+              <article key={card.id} className="border rounded-xl p-3">
+                <div className="text-sm font-medium">{card.contact}</div>
+                <div className="text-xs text-gray-500">
+                  {card.interest} · ${card.amount_estimated ?? 0}
+                </div>
+                <div className="text-xs">
+                  Próx. paso: {new Date(card.next_step_at).toLocaleString()}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+    </main>
+  )
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,16 @@
-import "./globals.css";
-import type { Metadata } from "next";
-import { ReactNode } from "react";
+import './globals.css'
+import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: "Next.js App",
-  description: "Generated setup",
-};
-
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  );
+  title: 'CRM Luis Ka',
+  description: 'Embudo Ahorro/GMM — Grupo Tres Hermosillo',
 }
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="es">
+      <body className="bg-gray-50 text-gray-900">{children}</body>
+    </html>
+  )
+}
+

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+import { useState } from 'react'
+import { supabaseBrowser } from '@/lib/supabase-browser'
+import { useRouter } from 'next/navigation'
+
+export default function Login() {
+  const s = supabaseBrowser()
+  const r = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [err, setErr] = useState<string | null>(null)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const { error } = await s.auth.signInWithPassword({ email, password })
+    if (error) setErr(error.message)
+    else r.push('/kanban')
+  }
+
+  return (
+    <main className="min-h-screen grid place-items-center p-6">
+      <form onSubmit={onSubmit} className="w-full max-w-sm space-y-3 border rounded-2xl p-6 bg-white">
+        <h1 className="text-xl font-semibold">Iniciar sesión</h1>
+        <input className="w-full border rounded p-2" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="w-full border rounded p-2" type="password" placeholder="Contraseña" value={password} onChange={e => setPassword(e.target.value)} />
+        {err && <p className="text-red-600 text-sm">{err}</p>}
+        <button className="w-full rounded-xl p-2 bg-[#004184] text-white">Entrar</button>
+      </form>
+    </main>
+  )
+}
+

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export const supabaseBrowser = () =>
+  createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,0 +1,22 @@
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export const supabaseServer = () =>
+  createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookies().get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          cookies().set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          cookies().set({ name, value: '', ...options, maxAge: 0 })
+        },
+      },
+    }
+  )
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const isAuth = req.cookies.get('sb-access-token')?.value
+  const isAuthPath = req.nextUrl.pathname.startsWith('/login')
+
+  if (!isAuth && !isAuthPath) {
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+  if (isAuth && isAuthPath) {
+    return NextResponse.redirect(new URL('/kanban', req.url))
+  }
+  return NextResponse.next()
+}
+
+export const config = { matcher: ['/((?!_next|favicon.ico|api).*)'] }
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@supabase/ssr": "^0.1.0",
     "@supabase/supabase-js": "^2.0.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.294.0",
     "next": "^14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add Supabase browser/server helpers and auth middleware
- create login and kanban pages with basic layout
- set up path alias and add UI dependencies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd4d5374832f9194fbbe01113326