### PR TITLE
Fix login session persistence and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ npm run dev
 
 ## Login
 
-Visit `/login` and sign in with a Supabase Auth user. The session is stored in cookies so the middleware can protect authenticated routes.
+Visit `/login` and sign in with a Supabase Auth user. On success the page reloads and the middleware redirects you to `/kanban`.
+If nothing happens, ensure your credentials and environment variables are correct.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,30 @@
 # CRM-Luiska
 
-This repository hosts a Next.js 14 project initialized with TypeScript, Tailwind CSS and ESLint.
+This repository hosts a Next.js 14 CRM prototype powered by Supabase.
+
+## Setup
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Create a `.env.local` file with your Supabase project keys:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=YOUR_SUPABASE_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
+```
 
 ## Development
+
+Run the local dev server:
 
 ```bash
 npm run dev
 ```
+
+## Login
+
+Visit `/login` and sign in with a Supabase Auth user. The session is stored in cookies so the middleware can protect authenticated routes.

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -18,10 +18,7 @@ export default function Login() {
     }
     const { error } = await s.auth.signInWithPassword({ email, password })
     if (error) setErr(error.message)
-    else {
-      r.push('/kanban')
-      r.refresh()
-    }
+    else r.refresh()
   }
 
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,6 +4,7 @@ import { supabaseBrowser } from '@/lib/supabase-browser'
 import { useRouter } from 'next/navigation'
 
 export default function Login() {
+  const s = supabaseBrowser()
   const r = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -11,14 +12,16 @@ export default function Login() {
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
-    const s = supabaseBrowser()
     if (!s) {
       setErr('Supabase not configured')
       return
     }
     const { error } = await s.auth.signInWithPassword({ email, password })
     if (error) setErr(error.message)
-    else r.push('/kanban')
+    else {
+      r.push('/kanban')
+      r.refresh()
+    }
   }
 
   return (

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,8 +1,30 @@
-import { createBrowserClient } from '@supabase/ssr'
+import { createBrowserClient, type CookieOptions } from '@supabase/ssr'
 
 export const supabaseBrowser = () => {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   if (!url || !key) return null
-  return createBrowserClient(url, key)
+  return createBrowserClient(url, key, {
+    cookies: {
+      get(name: string) {
+        const match = document.cookie
+          .split('; ')
+          .find(row => row.startsWith(`${name}=`))
+        return match?.split('=')[1] ?? null
+      },
+      set(name: string, value: string, options: CookieOptions) {
+        const merged = { path: '/', ...options }
+        const parts = [`${name}=${value}`, `path=${merged.path}`]
+        if (merged.maxAge) parts.push(`max-age=${merged.maxAge}`)
+        if (merged.expires) parts.push(`expires=${merged.expires.toUTCString()}`)
+        if (merged.sameSite) parts.push(`samesite=${merged.sameSite}`)
+        if (merged.secure) parts.push('secure')
+        document.cookie = parts.join('; ')
+      },
+      remove(name: string, options: CookieOptions) {
+        const merged = { path: '/', ...options }
+        document.cookie = `${name}=; path=${merged.path}; max-age=0`
+      },
+    },
+  })
 }


### PR DESCRIPTION
## Summary
- persist Supabase auth session in cookies for browser clients
- initialize browser client once and refresh after login redirect
- document environment setup and login usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae08c3ba84832fa2843a8d601b8d72