### PR TITLE
Redirect to Kanban after login

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,15 +10,20 @@ export default function Login() {
   const [password, setPassword] = useState('')
   const [err, setErr] = useState<string | null>(null)
 
-  async function onSubmit(e: React.FormEvent) {
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
+    setErr(null)
     if (!s) {
       setErr('Supabase not configured')
       return
     }
     const { error } = await s.auth.signInWithPassword({ email, password })
-    if (error) setErr(error.message)
-    else r.push('/kanban')
+    if (error) {
+      setErr(error.message)
+      return
+    }
+    r.push('/kanban')
+    r.refresh()
   }
 
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -18,7 +18,7 @@ export default function Login() {
     }
     const { error } = await s.auth.signInWithPassword({ email, password })
     if (error) setErr(error.message)
-    else r.refresh()
+    else r.push('/kanban')
   }
 
   return (


### PR DESCRIPTION
## Summary
- navigate to `/kanban` after successful password login

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c354748832fa05be89d3d33df26