### PR TITLE
Add contacts and tasks pages with navigation

### DIFF
--- a/app/contacts/page.tsx
+++ b/app/contacts/page.tsx
@@ -1,0 +1,43 @@
+import { supabaseServer } from '@/lib/supabase-server'
+import { redirect } from 'next/navigation'
+
+export default async function Contacts() {
+  const s = supabaseServer()
+  if (!s) return <main className="p-6">Supabase not configured</main>
+  const { data: { user } } = await s.auth.getUser()
+  if (!user) redirect('/login')
+  const { data: contacts } = await s
+    .from('crm.contacts')
+    .select('id,first_name,last_name,phone,email,city,source_id')
+    .order('created_at', { ascending: false })
+
+  return (
+    <main className="p-6">
+      <h1 className="text-xl font-semibold mb-4">Contactos</h1>
+      <div className="overflow-auto">
+        <table className="min-w-full border bg-white text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 border">Nombre</th>
+              <th className="p-2 border">Teléfono</th>
+              <th className="p-2 border">Email</th>
+              <th className="p-2 border">Ciudad</th>
+              <th className="p-2 border">Fuente</th>
+            </tr>
+          </thead>
+          <tbody>
+            {contacts?.map(c => (
+              <tr key={c.id}>
+                <td className="p-2 border">{c.first_name} {c.last_name}</td>
+                <td className="p-2 border">{c.phone}</td>
+                <td className="p-2 border">{c.email}</td>
+                <td className="p-2 border">{c.city}</td>
+                <td className="p-2 border">{c.source_id}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,22 @@
 import './globals.css'
 import type { Metadata } from 'next'
+import Navbar from '@/components/Navbar'
+import { supabaseServer } from '@/lib/supabase-server'
 
 export const metadata: Metadata = {
   title: 'CRM Luis Ka',
   description: 'Embudo Ahorro/GMM — Grupo Tres Hermosillo',
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const s = supabaseServer()
+  const { data: { user } } = s ? await s.auth.getUser() : { data: { user: null } }
   return (
     <html lang="es">
-      <body className="bg-gray-50 text-gray-900">{children}</body>
+      <body className="bg-gray-50 text-gray-900">
+        {user && <Navbar />}
+        {children}
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,9 @@
-export default function Home() {
-  return (
-    <main className="flex min-h-screen items-center justify-center p-24">
-      <h1 className="text-2xl font-bold">Hello World</h1>
-    </main>
-  );
+import { supabaseServer } from '@/lib/supabase-server'
+import { redirect } from 'next/navigation'
+
+export default async function Home() {
+  const s = supabaseServer()
+  if (!s) return <main className="p-6">Supabase not configured</main>
+  const { data: { user } } = await s.auth.getUser()
+  redirect(user ? '/kanban' : '/login')
 }

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,0 +1,41 @@
+import { supabaseServer } from '@/lib/supabase-server'
+import { redirect } from 'next/navigation'
+
+export default async function Tasks() {
+  const s = supabaseServer()
+  if (!s) return <main className="p-6">Supabase not configured</main>
+  const { data: { user } } = await s.auth.getUser()
+  if (!user) redirect('/login')
+  const { data: tasks } = await s
+    .from('crm.tasks')
+    .select('id,title,due_at,status,priority')
+    .order('due_at')
+
+  return (
+    <main className="p-6">
+      <h1 className="text-xl font-semibold mb-4">Tareas</h1>
+      <div className="overflow-auto">
+        <table className="min-w-full border bg-white text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 border">Título</th>
+              <th className="p-2 border">Fecha límite</th>
+              <th className="p-2 border">Prioridad</th>
+              <th className="p-2 border">Estado</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tasks?.map(t => (
+              <tr key={t.id}>
+                <td className="p-2 border">{t.title}</td>
+                <td className="p-2 border">{new Date(t.due_at).toLocaleString()}</td>
+                <td className="p-2 border">{t.priority}</td>
+                <td className="p-2 border">{t.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,21 @@
+'use client'
+import Link from 'next/link'
+import { supabaseBrowser } from '@/lib/supabase-browser'
+
+export default function Navbar() {
+  const s = supabaseBrowser()
+  async function logout() {
+    await s?.auth.signOut()
+    location.href = '/login'
+  }
+  return (
+    <nav className="p-4 bg-white border-b mb-4">
+      <ul className="flex gap-4 items-center">
+        <li><Link href="/kanban" className="font-medium">Kanban</Link></li>
+        <li><Link href="/contacts" className="font-medium">Contactos</Link></li>
+        <li><Link href="/tasks" className="font-medium">Tareas</Link></li>
+        <li className="ml-auto"><button onClick={logout} className="text-sm text-red-600">Salir</button></li>
+      </ul>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add shared navigation bar with logout
- list CRM contacts and tasks with supabase data
- redirect home to kanban after login

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae36b51818832faae523d6ce0fd2ff