### PR TITLE
Improve Supabase server handling

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { supabaseRoute } from '@/lib/supabase-route'
+
+export async function POST(req: Request) {
+  const { event, session } = await req.json()
+  const s = supabaseRoute()
+
+  if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+    if (!session) return NextResponse.json({ ok: false }, { status: 400 })
+    const { error } = await s.auth.setSession({
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+    })
+    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 })
+  }
+
+  if (event === 'SIGNED_OUT') {
+    await s.auth.signOut()
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { supabaseRoute } from '@/lib/supabase-route'
+
+export async function POST() {
+  const s = supabaseRoute()
+  await s.auth.signOut()
+  return NextResponse.json({ ok: true })
+}

--- a/lib/supabase-route.ts
+++ b/lib/supabase-route.ts
@@ -1,0 +1,22 @@
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export const supabaseRoute = () =>
+  createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookies().get(name)?.value
+        },
+        // ✅ Aquí SÍ podemos escribir cookies
+        set(name: string, value: string, options: CookieOptions) {
+          cookies().set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          cookies().set({ name, value: '', ...options, maxAge: 0 })
+        },
+      },
+    }
+  )

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,21 +1,21 @@
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
 export const supabaseServer = () => {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  if (!url || !key) return null
-  return createServerClient(url, key, {
-    cookies: {
-      get(name: string) {
-        return cookies().get(name)?.value
+  const cookieStore = cookies()
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        // ✅ Solo lectura en Server Components (páginas)
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        // ❌ No escribir cookies desde páginas (Next no lo permite)
+        set() {},
+        remove() {},
       },
-      set(name: string, value: string, options: CookieOptions) {
-        cookies().set({ name, value, ...options })
-      },
-      remove(name: string, options: CookieOptions) {
-        cookies().set({ name, value: '', ...options, maxAge: 0 })
-      },
-    },
-  })
+    }
+  )
 }


### PR DESCRIPTION
## Summary
- Restrict server-side Supabase helper to read-only cookies for pages
- Add Supabase route helper with cookie read/write support
- Implement auth callback and sign-out routes using the route helper

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b090ca2d28832fbf00f241afd58470