### PR TITLE
Use CRM schema for Supabase queries

### DIFF
--- a/app/contacts/new/page.tsx
+++ b/app/contacts/new/page.tsx
@@ -21,7 +21,7 @@ export default function NewContact() {
       setErr('Supabase not configured')
       return
     }
-    const { error } = await s.from('crm.contacts').insert({
+    const { error } = await s.from('contacts').insert({
       first_name: firstName,
       last_name: lastName,
       phone,

--- a/app/contacts/page.tsx
+++ b/app/contacts/page.tsx
@@ -8,7 +8,7 @@ export default async function Contacts() {
   const { data: { user } } = await s.auth.getUser()
   if (!user) redirect('/login')
   const { data: contacts } = await s
-    .from('crm.contacts')
+    .from('contacts')
     .select('id,first_name,last_name,phone,email,city,source_id')
     .order('created_at', { ascending: false })
 

--- a/app/kanban/page.tsx
+++ b/app/kanban/page.tsx
@@ -15,8 +15,8 @@ export default async function Kanban() {
   }
   const { data: { user } } = await s.auth.getUser()
   if (!user) redirect('/login')
-  const { data: stages } = await s.from('crm.stages').select('id,name,position').order('position')
-  const { data: opps }   = await s.from('crm.v_opps_kanban').select('*')
+  const { data: stages } = await s.from('stages').select('id,name,position').order('position')
+  const { data: opps }   = await s.from('v_opps_kanban').select('*')
 
   const grouped: Record<string, Card[]> = {}
   stages?.forEach((st: Stage) => (grouped[st.name] = []))

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -7,7 +7,7 @@ export default async function Tasks() {
   const { data: { user } } = await s.auth.getUser()
   if (!user) redirect('/login')
   const { data: tasks } = await s
-    .from('crm.tasks')
+    .from('tasks')
     .select('id,title,due_at,status,priority')
     .order('due_at')
 

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -5,6 +5,7 @@ export const supabaseBrowser = () => {
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   if (!url || !key) return null
   return createBrowserClient(url, key, {
+    db: { schema: 'crm' },
     cookies: {
       get(name: string) {
         const match = document.cookie

--- a/lib/supabase-route.ts
+++ b/lib/supabase-route.ts
@@ -6,6 +6,7 @@ export const supabaseRoute = () =>
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      db: { schema: 'crm' },
       cookies: {
         get(name: string) {
           return cookies().get(name)?.value

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -7,6 +7,7 @@ export const supabaseServer = () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      db: { schema: 'crm' },
       cookies: {
         // ✅ Solo lectura en Server Components (páginas)
         get(name: string) {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -2,5 +2,6 @@ import { createClient } from "@supabase/supabase-js";
 
 export const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL || "",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "",
+  { db: { schema: 'crm' } }
 );


### PR DESCRIPTION
## Summary
- Configure all Supabase clients to use the `crm` schema
- Query CRM tables without schema prefixes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b093a9c6e8832f944260d118f98e01