### PR TITLE
Rename Kanban view to Oportunidades

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ npm run dev
 
 ## Login
 
-Visit `/login` and sign in with a Supabase Auth user. On success the page reloads and the middleware redirects you to `/kanban`.
+Visit `/login` and sign in with a Supabase Auth user. On success the page reloads and the middleware redirects you to `/oportunidades`.
 If nothing happens, ensure your credentials and environment variables are correct.

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -20,7 +20,7 @@ export default function Login() {
       setErr(error.message)
       return
     }
-    location.href = '/kanban'
+    location.href = '/oportunidades'
   }
 
   return (

--- a/app/oportunidades/page.tsx
+++ b/app/oportunidades/page.tsx
@@ -8,7 +8,7 @@ type Card = {
   stage: string
 }
 
-export default async function Kanban() {
+export default async function Oportunidades() {
   const s = supabaseServer()
   if (!s) {
     return <main className="p-6">Supabase not configured</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,5 +5,5 @@ export default async function Home() {
   const s = supabaseServer()
   if (!s) return <main className="p-6">Supabase not configured</main>
   const { data: { user } } = await s.auth.getUser()
-  redirect(user ? '/kanban' : '/login')
+  redirect(user ? '/oportunidades' : '/login')
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,7 +11,7 @@ export default function Navbar() {
   return (
     <nav className="p-4 bg-white border-b mb-4">
       <ul className="flex gap-4 items-center">
-        <li><Link href="/kanban" className="font-medium">Kanban</Link></li>
+        <li><Link href="/oportunidades" className="font-medium">Oportunidades</Link></li>
         <li><Link href="/contacts" className="font-medium">Contactos</Link></li>
         <li><Link href="/tasks" className="font-medium">Tareas</Link></li>
         <li className="ml-auto"><button onClick={logout} className="text-sm text-red-600">Salir</button></li>


### PR DESCRIPTION
## Summary
- rename Kanban menu entry and page to Oportunidades

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0e2be1670832f85ef0241cfac60e8