### PR TITLE
fix: default Supabase schema to public

### DIFF
--- a/app/oportunidades/new/page.tsx
+++ b/app/oportunidades/new/page.tsx
@@ -22,7 +22,7 @@ export default function NewOpportunity() {
   useEffect(() => {
     if (!s) return
     s
-      .from('contacts')
+      .from('public.contacts')
       .select('id,first_name,last_name')
       .then(({ data }) => {
         const mapped = data?.map((c: any) => ({
@@ -32,7 +32,7 @@ export default function NewOpportunity() {
         setContacts(mapped ?? [])
       })
     s
-      .from('sources')
+      .from('public.sources')
       .select('id,name')
       .order('id')
       .then(({ data, error }) => {
@@ -61,7 +61,7 @@ export default function NewOpportunity() {
       setErr('No user')
       return
     }
-    const { data: oppId, error: oppErr } = await s.rpc('create_opportunity', {
+    const { data: oppId, error: oppErr } = await s.rpc('public.create_opportunity', {
       p_contact_id: contactId,
       p_interest: interest,
       p_amount: amount ? Number(amount) : null,
@@ -76,7 +76,7 @@ export default function NewOpportunity() {
       const updates: any = {}
       if (probability) updates.probability = Number(probability)
       if (nextStep) updates.next_step_at = new Date(nextStep).toISOString()
-      await s.from('opportunities').update(updates).eq('id', oppId)
+      await s.from('public.opportunities').update(updates).eq('id', oppId)
     }
     router.push('/oportunidades')
   }

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -5,6 +5,7 @@ export const supabaseBrowser = () => {
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   if (!url || !key) return null
   return createBrowserClient(url, key, {
+    db: { schema: 'public' },
     cookies: {
       get(name: string) {
         const match = document.cookie

--- a/lib/supabase-route.ts
+++ b/lib/supabase-route.ts
@@ -6,6 +6,7 @@ export const supabaseRoute = () =>
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      db: { schema: 'public' },
       cookies: {
         get(name: string) {
           return cookies().get(name)?.value

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -7,6 +7,7 @@ export const supabaseServer = () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      db: { schema: 'public' },
       cookies: {
         // ✅ Solo lectura en Server Components (páginas)
         get(name: string) {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -3,4 +3,7 @@ import { createClient } from "@supabase/supabase-js";
 export const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL || "",
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "",
+  {
+    db: { schema: 'public' },
+  },
 );


### PR DESCRIPTION
## Summary
- ensure Supabase clients explicitly use the `public` schema

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0ee09dcb4832fa1a2c6099aafd06d